### PR TITLE
RMET-354 FilePlugin - Added read permissions logic to ask for permissions when needed

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -133,7 +133,6 @@ to config.xml in order for the application to find previously stored files.
             <allow-navigation href="cdvfile:*" />
         </config-file>
         <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
-            <application android:requestLegacyExternalStorage="true" />
         </edit-config>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -132,8 +132,6 @@ to config.xml in order for the application to find previously stored files.
             </feature>
             <allow-navigation href="cdvfile:*" />
         </config-file>
-        <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
-        </edit-config>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
         </config-file>

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -334,6 +334,10 @@ public class FileUtils extends CordovaPlugin {
                     int start = args.getInt(1);
                     int end = args.getInt(2);
                     String fname=args.getString(0);
+                    String nativeURL = resolveLocalFileSystemURI(fname).getString("nativeURL");
+                    if(needPermission(nativeURL, READ)) {
+                        getReadPermission(rawArgs, ACTION_GET_FILE, callbackContext);
+                    }
                     readFileAs(fname, start, end, callbackContext, null, PluginResult.MESSAGE_TYPE_ARRAYBUFFER);
                 }
             }, rawArgs, callbackContext);

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -330,7 +330,7 @@ public class FileUtils extends CordovaPlugin {
         }
         else if (action.equals("readAsArrayBuffer")) {
             threadhelper( new FileOp( ){
-                public void run(JSONArray args) throws JSONException, MalformedURLException  {
+                public void run(JSONArray args) throws JSONException, IOException  {
                     int start = args.getInt(1);
                     int end = args.getInt(2);
                     String fname=args.getString(0);


### PR DESCRIPTION
## Description
Added code to check for read permissions and, if necessary, ask for them, when trying to read a file, in readAsArrayBuffer option (for the GetFileDataFromURI client action).


## Context
Fixes: https://outsystemsrd.atlassian.net/browse/RMET-354

Now it is possible to open media files that are in external storage. For non-media files in external storage, a file chooser needs to be used.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)


## Platforms affected
- [x] Android
- [ ] iOS

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested the changes locally in my machine, using the FilePluginTest app available in the DEV environment (since this functionality is not available in the FilePlugin SampleApp).

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly