### PR TITLE
RMET-1283 Write file in blocks for memory economy

### DIFF
--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cordova.file;
 
+import static java.lang.Math.min;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -410,8 +410,7 @@ public class LocalFilesystem extends Filesystem {
                     blockOffset += blockSize;
                 }
             }
-
-            // Always close the output
+            
             if (isPublicDirectory(absolutePath)) {
                 broadcastNewFile(Uri.fromFile(new File(absolutePath)));
             }


### PR DESCRIPTION
### Motivation and Context
This PR fixes the logic that writes a file to the disk. 
Instead of writing the whole file in one go, we write it in blocks to avoid using too much memory on byte arrays.

### Description
https://outsystemsrd.atlassian.net/browse/RMET-1283

### Platforms affected
- [x] Android
- [ ] iOS
- [ ] JS

### Testing
Testing using MABS.
UITests all passed.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
