### PR TITLE
RMET-3681 :: Javascript :: Refactor `FileReader` to `CordovaFileReader`

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,10 @@
 -->
 # Release Notes
 
+### 6.0.2-OS6 (Sept 23, 2024)
+- Fix: Re-write FileReader as CordovaFileReader, avoiding the FileReader API wrapping (https://outsystemsrd.atlassian.net/browse/RMET-3681
+)
+
 ### 6.0.2-OS5 (Jan 10, 2022)
 - Fix: Write file to disk as blocks to avoid big memory allocation on Android (https://outsystemsrd.atlassian.net/browse/RMET-1283)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,8 +57,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <clobbers target="window.FileError" />
     </js-module>
 
-    <js-module src="www/FileReader.js" name="FileReader">
-        <clobbers target="window.FileReader" />
+    <js-module src="www/CordovaFileReader.js" name="CordovaFileReader">
+        <clobbers target="window.CordovaFileReader" />
     </js-module>
 
     <js-module src="www/FileSystem.js" name="FileSystem">

--- a/www/FileWriter.js
+++ b/www/FileWriter.js
@@ -21,7 +21,7 @@
 
 var exec = require('cordova/exec');
 var FileError = require('./FileError');
-var FileReader = require('./FileReader');
+var CordovaFileReader = require('./CordovaFileReader');
 var ProgressEvent = require('./ProgressEvent');
 
 /**
@@ -107,7 +107,7 @@ FileWriter.prototype.write = function (data, isPendingBlobReadResult) {
 
     // Check to see if the incoming data is a blob
     if (data instanceof File || (!isProxySupportBlobNatively && supportsBinary && data instanceof Blob)) {
-        var fileReader = new FileReader();
+        var fileReader = new CordovaFileReader();
         /* eslint-enable no-undef */
         fileReader.onload = function () {
             // Call this method again, with the arraybuffer as argument


### PR DESCRIPTION
## Description
In ODC's client runtime, both the used `zonejs` and the file plugin were overwriting the web's `FileReader` API. This meant that, depending on the order of execution, the `zonejs` `FileReader` would be the one being used by the plugin, which would result in the reader's events never being triggered.

This PR fixes it by not overwritting the `FileReader`, insteading  creating a new one `CordovaFileReader`

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3681

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly