### PR TITLE
RMET-3856 - Add `READ_EXTERNAL_STORAGE` permission

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,9 @@
 -->
 # Release Notes
 
+### 6.0.2-OS7 (Nov 22, 2024)
+- Fix: Add `READ_EXTERNAL_STORAGE` permission to plugin (https://outsystemsrd.atlassian.net/browse/RMET-3856)
+
 ### 6.0.2-OS6 (Sept 23, 2024)
 - Fix: Re-write FileReader as CordovaFileReader, avoiding the FileReader API wrapping (https://outsystemsrd.atlassian.net/browse/RMET-3681
 )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file",
-  "version": "6.0.2-OS6",
+  "version": "6.0.2-OS7",
   "description": "Cordova File Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-file"
-      version="6.0.2-OS6">
+      version="6.0.2-OS7">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -138,6 +138,7 @@ to config.xml in order for the application to find previously stored files.
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
         </config-file>
 
         <source-file src="src/android/EncodingException.java" target-dir="src/org/apache/cordova/file" />


### PR DESCRIPTION

## Description

- Adds the `READ_EXTERNAL_STORAGE` permission to the `AndroidManifest.xml` of the app through the `plugin.xml` file.

## Context

Before, the Cordova native shell was adding this permission by default. But starting with MABS 11, not anymore, so the plugin must add all the permissions it requires.

References: https://outsystemsrd.atlassian.net/browse/RMET-3856

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly
