### PR TITLE
RMET-3998 :: fix: detecting content scheme in Uris

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,9 @@
 -->
 # Release Notes
 
+### 6.0.2-OS8 (Jan 20, 2025)
+- Fix: Android: Opening content:// Uri's (https://outsystemsrd.atlassian.net/browse/RMET-3998)
+
 ### 6.0.2-OS7 (Nov 22, 2024)
 - Fix: Android: Add `READ_EXTERNAL_STORAGE` permission to plugin (https://outsystemsrd.atlassian.net/browse/RMET-3856)
 - Fix: Android: Allow reading data from URIs retrieved from the photo picker (https://outsystemsrd.atlassian.net/browse/RMET-3632)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file",
-  "version": "6.0.2-OS7",
+  "version": "6.0.2-OS8",
   "description": "Cordova File Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-file"
-      version="6.0.2-OS7">
+      version="6.0.2-OS8">
     <name>File</name>
     <description>Cordova File Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/ContentFilesystem.java
+++ b/src/android/ContentFilesystem.java
@@ -36,8 +36,8 @@ public class ContentFilesystem extends Filesystem {
 
     private final Context context;
     private static final String SYNTHETIC_URI_PREFIX = "/synthetic/";
-    static final String CONTENT_SCHEME = "content://";
     private static final String CONTENT_SCHEME_NAME = "content";
+    static final String CONTENT_SCHEME = CONTENT_SCHEME_NAME + "://";
 
 	public ContentFilesystem(Context context, CordovaResourceApi resourceApi) {
 		super(Uri.parse(CONTENT_SCHEME), CONTENT_SCHEME_NAME, resourceApi);

--- a/src/android/ContentFilesystem.java
+++ b/src/android/ContentFilesystem.java
@@ -37,9 +37,10 @@ public class ContentFilesystem extends Filesystem {
     private final Context context;
     private static final String SYNTHETIC_URI_PREFIX = "/synthetic/";
     static final String CONTENT_SCHEME = "content://";
+    private static final String CONTENT_SCHEME_NAME = "content";
 
 	public ContentFilesystem(Context context, CordovaResourceApi resourceApi) {
-		super(Uri.parse(CONTENT_SCHEME), "content", resourceApi);
+		super(Uri.parse(CONTENT_SCHEME), CONTENT_SCHEME_NAME, resourceApi);
         this.context = context;
     }
     
@@ -80,7 +81,7 @@ public class ContentFilesystem extends Filesystem {
         if (path != null && path.contains(SYNTHETIC_URI_PREFIX)) {
             inputURL = convertSyntheticUri(path);
         }
-        if (!CONTENT_SCHEME.substring(0, CONTENT_SCHEME.length() - 2).equals(inputURL.getScheme())) {
+        if (!CONTENT_SCHEME_NAME.equals(inputURL.getScheme())) {
             return null;
         }
         String subPath = inputURL.getEncodedPath();


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

Fixes the matching of Content Uri scheme, was checking for `content:` instead of `content`


### What testing has been done on this change?

Tested on an Outsystems app that was used to validate a similar issue recently:

- [Current File Plugin version build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=e0cc5731a5f3b2f50df505b1254ca2a670bd9733&stg=dev) - Fails to open an image from photo picker
- [Build using the branch of this PR](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=45bae835ebccff0e4f38da92e7845e47a0cb55d4&stg=dev) - Works
