### PR TITLE
RMET-4021 ::: Fix readAsArrayBuffer on Android >= 13

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,10 @@
 -->
 # Release Notes
 
+### Unreleased (Jan 24, 2025)
+- Fix: Android: Reading from external storage on Android 13 and above (https://outsystemsrd.atlassian.net/browse/RMET-4021)
+- Fix: Android: Getting local file without "file://" in uri (https://outsystemsrd.atlassian.net/browse/RMET-4021)
+
 ### 6.0.2-OS8 (Jan 20, 2025)
 - Fix: Android: Opening content:// Uri's (https://outsystemsrd.atlassian.net/browse/RMET-3998)
 

--- a/src/android/ContentFilesystem.java
+++ b/src/android/ContentFilesystem.java
@@ -35,7 +35,7 @@ import org.json.JSONObject;
 public class ContentFilesystem extends Filesystem {
 
     private final Context context;
-    private static final String SYNTHETIC_URI_PREFIX = "/synthetic/";
+    static final String SYNTHETIC_URI_PREFIX = "/synthetic/";
     private static final String CONTENT_SCHEME_NAME = "content";
     static final String CONTENT_SCHEME = CONTENT_SCHEME_NAME + "://";
 

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -47,7 +47,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.security.Permission;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -79,6 +78,7 @@ public class FileUtils extends CordovaPlugin {
     public static final int ACTION_GET_FILE = 0;
     public static final int ACTION_WRITE = 1;
     public static final int ACTION_GET_DIRECTORY = 2;
+    public static final int ACTION_READ_ARRAY_BUFFER = 5;
 
     public static final int WRITE = 3;
     public static final int READ = 4;
@@ -338,9 +338,10 @@ public class FileUtils extends CordovaPlugin {
                     String fname=args.getString(0);
                     String nativeURL = resolveLocalFileSystemURI(fname).getString("nativeURL");
                     if(needPermission(nativeURL, READ)) {
-                        getReadPermission(rawArgs, ACTION_GET_FILE, callbackContext);
+                        getReadPermission(rawArgs, ACTION_READ_ARRAY_BUFFER, callbackContext);
+                    } else {
+                        readFileAs(fname, start, end, callbackContext, null, PluginResult.MESSAGE_TYPE_ARRAYBUFFER);
                     }
-                    readFileAs(fname, start, end, callbackContext, null, PluginResult.MESSAGE_TYPE_ARRAYBUFFER);
                 }
             }, rawArgs, callbackContext);
         }
@@ -576,6 +577,10 @@ public class FileUtils extends CordovaPlugin {
     private boolean needPermission(String nativeURL, int permissionType) throws JSONException {
         if (nativeURL.startsWith(CONTENT_SCHEME)) {
             return false; // Content URIs don't need explicit permissions
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // legacy storage permissions not usable on Android 13 and above
+            //  and we don't want to request READ_MEDIA_IMAGES nor READ_MEDIA_VIDEO permissions
+            return false;
         }
         
         JSONObject j = requestAllPaths();
@@ -1224,6 +1229,16 @@ public class FileUtils extends CordovaPlugin {
                             Boolean isBinary=args.getBoolean(3);
                             long fileSize = write(fname, data, offset, isBinary);
                             req.getCallbackContext().sendPluginResult(new PluginResult(PluginResult.Status.OK, fileSize));
+                        }
+                    }, req.getRawArgs(), req.getCallbackContext());
+                    break;
+                case ACTION_READ_ARRAY_BUFFER:
+                    threadhelper( new FileOp( ){
+                        public void run(JSONArray args) throws JSONException, FileNotFoundException, IOException, NoModificationAllowedException {
+                            int start = args.getInt(1);
+                            int end = args.getInt(2);
+                            String fname=args.getString(0);
+                            readFileAs(fname, start, end, req.getCallbackContext(), null, PluginResult.MESSAGE_TYPE_ARRAYBUFFER);
                         }
                     }, req.getRawArgs(), req.getCallbackContext());
                     break;

--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -575,13 +575,12 @@ public class FileUtils extends CordovaPlugin {
     }
 
     private boolean needPermission(String nativeURL, int permissionType) throws JSONException {
-        if (nativeURL.startsWith(CONTENT_SCHEME)) {
-            return false; // Content URIs don't need explicit permissions
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU || nativeURL.startsWith(CONTENT_SCHEME)) {
             // legacy storage permissions not usable on Android 13 and above
             //  and we don't want to request READ_MEDIA_IMAGES nor READ_MEDIA_VIDEO permissions
+            // Also, Content URIs don't need any permission requests
             return false;
-        }
+        } 
         
         JSONObject j = requestAllPaths();
         ArrayList<String> allowedStorageDirectories = new ArrayList<String>();

--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -19,7 +19,6 @@
 package org.apache.cordova.file;
 
 import static java.lang.Math.min;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -73,7 +72,7 @@ public class LocalFilesystem extends Filesystem {
 
     @Override
     public LocalFilesystemURL toLocalUri(Uri inputURL) {
-        if (!"file".equals(inputURL.getScheme())) {
+        if (!isValidLocalUri(inputURL)) {
             return null;
         }
         File f = new File(inputURL.getPath());
@@ -101,6 +100,18 @@ public class LocalFilesystem extends Filesystem {
             b.appendEncodedPath("");
         }
         return LocalFilesystemURL.parse(b.build());
+    }
+
+    private boolean isValidLocalUri(Uri inputURL) {
+        String scheme = inputURL.getScheme();
+        if (scheme == null) {
+            String path = inputURL.getPath();
+            // if contains synthetic, then it is meant to be a content url
+            //  otherwise, it can be a valid file path just without the file:// scheme
+            return path != null && !path.contains(ContentFilesystem.SYNTHETIC_URI_PREFIX);
+        } else {
+            return scheme.equals("file");
+        }
     }
 
 	@Override

--- a/src/android/LocalFilesystem.java
+++ b/src/android/LocalFilesystem.java
@@ -109,9 +109,8 @@ public class LocalFilesystem extends Filesystem {
             // if contains synthetic, then it is meant to be a content url
             //  otherwise, it can be a valid file path just without the file:// scheme
             return path != null && !path.contains(ContentFilesystem.SYNTHETIC_URI_PREFIX);
-        } else {
-            return scheme.equals("file");
         }
+        return scheme.equals("file");
     }
 
 	@Override


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### What does this PR do?

Fixes `readAsArrayBuffer` when reading files from external storage (e.g. videos recorded from Camera Plugin with saveToGallery=true).

Affects only Android versions >= 13, because the issue was related to requesting READ_EXTERNAL_STORAGE, which shouldn't be required for media files, and READ_EXTERNAL_STORAGE is never granted for apps above Android 12.

Also fixed another issue where local files would only be read if file:// was in the uri.

References: https://outsystemsrd.atlassian.net/browse/RMET-4021

### What testing has been done on this change?

- [Use a Test App](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=ace667b4632e80f3fb39e5390e29e4c967ff0889&stg=dev) that integrates Outsystems Camera Plugin's RecordVideo and File Plugin's GetFileDataFromUri (which calls readAsArrayBuffer), on devices both above Android 13 and below it. Should be able to read video files on any Android version now.
- [Testing on Outsystems File Sample App](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=1c88175f3bf80df85f2af50a9caec053afa6fa5e&stg=dev) to confirm nothing was broken.

